### PR TITLE
Update contribution guidelines and add EditorConfig

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -1,0 +1,14 @@
+# EditorConfig is awesome: http://EditorConfig.org
+
+# top-most EditorConfig file
+root = true
+
+[*]
+end_of_line = lf
+insert_final_newline = true
+indent_style = space
+indent_size = 4
+charset = utf-8
+
+[{!*.md,!*.markdown}]
+trim_trailing_whitespace = true

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -10,5 +10,8 @@ Please ensure your pull request adheres to the following guidelines:
 * End all descriptions with a full stop/period.
 * Check your spelling and grammar.
 * New categories, or improvements to the existing categorisation are welcome.
+* Category names have to be alphabetically sorted from A-Z.
+* Entry names inside categories have to be alphabetically sorted from A-Z.
+* Please use [EditorConfig](http://editorconfig.org) to ensure consistent line-endings, tabs/spaces, etc. or make sure, that your editor does satisfy the coding styles defined within [.editorconfig](https://github.com/drobakowski/awesome-erlang/blob/master/.editorconfig).
 
 Thank you for your suggestions!


### PR DESCRIPTION
In order to avoid some kind a prioritization of some libraries and for a better overview, I've updated the coding guidelines so that the categories and category entries should be sorted alphabetically from A-Z. The additional EditorConfig, copied from awesome-elixir, will bring more code style consistence between different editors and IDEs. Thanks @h4cc!