### PR TITLE
remove dead jsonrec library

### DIFF
--- a/README.md
+++ b/README.md
@@ -172,7 +172,6 @@ A curated list of amazingly awesome Erlang libraries, resources and shiny thing 
 
 * [eql](https://github.com/artemeff/eql) - Erlang with SQL or not.
 * [jiffy](https://github.com/davisp/jiffy) - JSON NIFs for Erlang.
-* [jsonrec](https://github.com/EduardSergeev/jsonrec) - JSON encoder/decoder with the ability to map to records.
 * [jsx](https://github.com/talentdeficit/jsx) - An erlang application for consuming, producing and manipulating json.
 * [qsp](https://github.com/artemeff/qsp) - Enhanced query string parser for Erlang.
 


### PR DESCRIPTION
It itself can't compile on OTP 18.0+. After changing type specs here and there it will compile, but if you try to use it compiler will crash.