### PR TITLE
Added rec2json as alternative to jsonrec.

### DIFF
--- a/README.md
+++ b/README.md
@@ -189,10 +189,9 @@ A curated list of amazingly awesome Erlang libraries, resources and shiny thing 
 
 * [eql](https://github.com/artemeff/eql) - Erlang with SQL or not.
 * [jiffy](https://github.com/davisp/jiffy) - JSON NIFs for Erlang.
-* [rec2json](https://github.com/lordnull/rec2json) - Generate JSON encoder/decoder from record specs.
-* [jsonrec](https://github.com/EduardSergeev/jsonrec) - JSON encoder/decoder with the ability to map to records.
 * [jsx](https://github.com/talentdeficit/jsx) - An erlang application for consuming, producing and manipulating json.
 * [qsp](https://github.com/artemeff/qsp) - Enhanced query string parser for Erlang.
+* [rec2json](https://github.com/lordnull/rec2json) - Generate JSON encoder/decoder from record specs.
 
 ## REST and API
 *Libraries and web tools for developing REST-ful APIs.*

--- a/README.md
+++ b/README.md
@@ -189,6 +189,7 @@ A curated list of amazingly awesome Erlang libraries, resources and shiny thing 
 
 * [eql](https://github.com/artemeff/eql) - Erlang with SQL or not.
 * [jiffy](https://github.com/davisp/jiffy) - JSON NIFs for Erlang.
+* [rec2json](https://github.com/lordnull/rec2json) - Generate JSON encoder/decoder from record specs.
 * [jsonrec](https://github.com/EduardSergeev/jsonrec) - JSON encoder/decoder with the ability to map to records.
 * [jsx](https://github.com/talentdeficit/jsx) - An erlang application for consuming, producing and manipulating json.
 * [qsp](https://github.com/artemeff/qsp) - Enhanced query string parser for Erlang.


### PR DESCRIPTION
The two libraries have similar goals, and were started at about the same
time. However, rec2json is still actively maintained, and has mechanisms to
allow user defined types to be converted.