### PR TITLE
add erlang-pure-migrations to curated list

### DIFF
--- a/README.md
+++ b/README.md
@@ -171,6 +171,7 @@ A curated list of amazingly awesome Erlang libraries, resources and shiny thing 
 * [epgsql](https://github.com/epgsql/epgsql) - PostgreSQL Driver for Erlang.
 * [mysql-otp](https://github.com/mysql-otp/mysql-otp) - MySQL/OTP – MySQL driver for Erlang/OTP.
 * [pgsql_migration](https://github.com/artemeff/pgsql_migration) – PostgreSQL migrations for Erlang.
+* [erlang-pure-migrations](https://github.com/bearmug/erlang-pure-migrations) – PostgreSQL/MySQL migrations for Erlang.
 
 ## Queue
 *Libraries for working with event and task queues.*


### PR DESCRIPTION
Dear awesome list curators, here is one more tool, which I propose for the list adoption.

**What**
Awesome onboarding for database version control engine [erlang-pure-migrations](https://github.com/bearmug/erlang-pure-migrations).

**Why**
- PostgreSQL/MySQL support out-of-the-box
- a number of real and continuously verified integrations (3 for PostgreSQL and 1 for MySQL)
- reasonable errors and problems reporting
- built-in quality controls metrics
- extensive usage code snippets for each integration
- effects-free engine with detailed mechanics explanation